### PR TITLE
Added code to display output from stdout of the mpirun process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,4 +77,4 @@ wheels/
 *.egg-info/
 .installed.cfg
 *.egg
-
+.idea/

--- a/SirIsaac/generateEnsembleParallel.py
+++ b/SirIsaac/generateEnsembleParallel.py
@@ -55,3 +55,4 @@ output = ensGen.generateEnsemble(dataModel,initialParameters,   \
 # Write data to file
 save(output,outputFilename)
 
+print "MPIEND"

--- a/SirIsaac/localFitParallel.py
+++ b/SirIsaac/localFitParallel.py
@@ -146,4 +146,4 @@ else:
 #### if worker
 
 comm.finalize()
-
+print "MPIEND"


### PR DESCRIPTION
I have used threading to continue code after the `mpirun` subprocess call and the main thread monitors stdout textfile assigned in the subprocess call. The monitoring ends after the subprocess outputs "MPIEND" string on the stdout. The threads are joined after the monitoring ends.