### PR TITLE
Added code to display output from stdout of the mpirun process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,6 +75,7 @@ sdist/
 var/
 wheels/
 *.egg-info/
+.idea/
 .installed.cfg
 *.egg
 

--- a/SirIsaac/generateEnsembleParallel.py
+++ b/SirIsaac/generateEnsembleParallel.py
@@ -55,3 +55,4 @@ output = ensGen.generateEnsemble(dataModel,initialParameters,   \
 # Write data to file
 save(output,outputFilename)
 
+print "MPIEND"

--- a/SirIsaac/localFitParallel.py
+++ b/SirIsaac/localFitParallel.py
@@ -166,4 +166,4 @@ else:
 #### if worker
 
 pypar.finalize()
-
+print "MPIEND"


### PR DESCRIPTION
I've added an extra method `mpithread` in class `EnsembleGenerator`, which is a thread function for running `mpirun` subprocess. The rest of the code continues because I've made the thread as daemon threads. The main thread then monitors and outputs the stdout of `mpirun` subprocess. The monitoring ends after the main thread encounters "MPIEND" string on the stdout. The threads are joined after monitoring ends.