### PR TITLE
Fix for parallel issues

### DIFF
--- a/SirIsaac/fittingProblem.py
+++ b/SirIsaac/fittingProblem.py
@@ -1721,7 +1721,7 @@ class SloppyCellFittingModel(FittingModel):
                 bestParams = fitParams
                 bestConvFlag = convFlag
         else: # run in parallel 3.21.2012
-            outputDict = self.localFitToData_pypar(self.numprocs,fittingData,
+            outputDict = self.localFitToData_parallel(self.numprocs,fittingData,
                 dataModel,ens,indepParamsList)
             indices = scipy.sort(outputDict.keys())
             self.costList = [ outputDict[i][2] for i in indices ]
@@ -1797,13 +1797,14 @@ class SloppyCellFittingModel(FittingModel):
             return fitParameters,convFlag
 
     # 3.21.2012
-    def localFitToData_pypar(self,numprocs,fittingData,dataModel,startParamsList,indepParamsList):
+    def localFitToData_parallel(self,numprocs,fittingData,dataModel,
+        startParamsList,indepParamsList):
         """
-        Uses pypar to run many local fits (localFitToData) in parallel.
+        Uses mpi4py to run many local fits (localFitToData) in parallel.
         """
 
         scipy.random.seed()
-        prefix = "temporary_" + str(os.getpid()) + "_localFitToData_pypar_"
+        prefix = "temporary_" + str(os.getpid()) + "_localFitToData_parallel_"
         inputDictFilename = prefix + "inputDict.data"
         outputFilename = prefix + "output.data"
         inputDict = { 'fittingProblem':self,
@@ -1826,12 +1827,12 @@ class SloppyCellFittingModel(FittingModel):
             os.remove(outputFilename)
             os.remove(prefix+"stdout.txt")
         except IOError:
-            print "localFitToData_pypar error:"
+            print "localFitToData_parallel error:"
             stdoutFile = open(prefix+"stdout.txt")
             stdout = stdoutFile.read()
             print stdout
             os.remove(prefix+"stdout.txt")
-            raise Exception, "localFitToData_pypar:"                            \
+            raise Exception, "localFitToData_parallel:"                            \
                 + " error in localFitParallel.py"
 
         return output

--- a/SirIsaac/fittingProblem.py
+++ b/SirIsaac/fittingProblem.py
@@ -1809,7 +1809,7 @@ class SloppyCellFittingModel(FittingModel):
         stdoutFile = open(prefix+"stdout.txt",'w')
         subprocess.call([ "mpirun","-np",str(numprocs),"python",
                           os.path.join(SIRISAACDIR, "localFitParallel.py"),
-                          inputDictFilename, "--disableC" ],
+                          inputDictFilename ],
                         stderr=stdoutFile,stdout=stdoutFile,env=os.environ)
         stdoutFile.close()
         os.remove(inputDictFilename)

--- a/SirIsaac/fittingProblem.py
+++ b/SirIsaac/fittingProblem.py
@@ -1807,8 +1807,10 @@ class SloppyCellFittingModel(FittingModel):
 
         # call mpi
         stdoutFile = open(prefix+"stdout.txt",'w')
-        subprocess.call([ "mpirun","-np",str(numprocs),"python",os.path.join(SIRISAACDIR, "localFitParallel.py"),
-              inputDictFilename ], stderr=stdoutFile,stdout=stdoutFile,env=os.environ)
+        subprocess.call([ "mpirun","-np",str(numprocs),"python",
+                          os.path.join(SIRISAACDIR, "localFitParallel.py"),
+                          inputDictFilename, "--disableC" ],
+                        stderr=stdoutFile,stdout=stdoutFile,env=os.environ)
         stdoutFile.close()
         os.remove(inputDictFilename)
 
@@ -2629,7 +2631,8 @@ class EnsembleGenerator():
           #         between-h5py-subprocess-and-mpirun
           stdoutFile = open(prefix+"stdout.txt",'w')
           subprocess.call([ "mpirun","-np",str(numprocs),"python",
-                os.path.join(SIRISAACDIR, "generateEnsembleParallel.py"),inputDictFilename ],
+                os.path.join(SIRISAACDIR, "generateEnsembleParallel.py"),
+                inputDictFilename, "--disableC" ],
                 stderr=stdoutFile,stdout=stdoutFile,env=os.environ)
           stdoutFile.close()
           os.remove(inputDictFilename)

--- a/SirIsaac/fittingProblem.py
+++ b/SirIsaac/fittingProblem.py
@@ -42,7 +42,7 @@ except ImportError:
 if (os.uname()[1] != 'star'):
     from simulateYeastOscillator import *
 import pylab
-import subprocess # for network figures and pypar
+import subprocess # for network figures and mpi
 from linalgTools import svdInverse
 import copy
 
@@ -52,16 +52,6 @@ import sets
 
 from simplePickle import load,save
 
-# 3.20.2020 Disable SloppyCell's pypar unless we are running in parallel.
-# This addresses issues with error handling when parallel threads are spawned
-# from an original non-parallel call (as in generateEnsemble_pypar).
-if Ensembles.HAVE_PYPAR and Ensembles.num_procs == 1:
-    # disable pypar
-    Ensembles.pypar.finalize()
-    # avoid having finalize be called again at exit,
-    # which would produce an error message
-    import atexit
-    atexit._exithandlers.remove((Ensembles.pypar.finalize,(),{}))
     
 
 avegtolDefault = 1e-8
@@ -1626,7 +1616,7 @@ class SloppyCellFittingModel(FittingModel):
         elif self.ensGen != None:
             startTimeEns = time.clock()
             if self.numprocs > 1:
-                ens,ratio = self.ensGen.generateEnsemble_pypar(self.numprocs,
+                ens,ratio = self.ensGen.generateEnsemble_parallel(self.numprocs,
                     dataModel,initialParameters,verbose=self.verbose)
             else:
                 ens,ratio = self.ensGen.generateEnsemble(dataModel,
@@ -1818,7 +1808,7 @@ class SloppyCellFittingModel(FittingModel):
         # call mpi
         stdoutFile = open(prefix+"stdout.txt",'w')
         subprocess.call([ "mpirun","-np",str(numprocs),"python",os.path.join(SIRISAACDIR, "localFitParallel.py"),
-              inputDictFilename ], stderr=stdoutFile,stdout=stdoutFile)
+              inputDictFilename ], stderr=stdoutFile,stdout=stdoutFile,env=os.environ)
         stdoutFile.close()
         os.remove(inputDictFilename)
 
@@ -2610,19 +2600,19 @@ class EnsembleGenerator():
         else:
           return keptEns,ratio
 
-    def generateEnsemble_pypar(self,numprocs,dataModel,initialParameters,
+    def generateEnsemble_parallel(self,numprocs,dataModel,initialParameters,
           returnCosts=False,scaleByDOF=True,verbose=True):
           """
-          Uses SloppyCell's built-in pypar support to run ensemble generation
+          Uses SloppyCell's built-in mpi4py support to run ensemble generation
           (generateEnsemble) in parallel.
           """
           if verbose:
-            print "generateEnsemble_pypar: Generating parameter ensemble with " \
+            print "generateEnsemble_parallel: Generating parameter ensemble with " \
               +str(self.totalSteps)+" total members, using "                    \
               +str(numprocs)+" processors."
 
           scipy.random.seed()
-          prefix = "temporary_" + str(os.getpid()) + "_generateEnsemble_pypar_"
+          prefix = "temporary_" + str(os.getpid()) + "_generateEnsemble_parallel_"
           inputDictFilename = prefix + "inputDict.data"
           outputFilename = prefix + "output.data"
           inputDict = { 'ensGen':self,
@@ -2634,10 +2624,13 @@ class EnsembleGenerator():
           save(inputDict,inputDictFilename)
 
           # call mpi
+          # for info on "env=os.environ", see
+          # https://stackoverflow.com/questions/60060142/strange-interaction-
+          #         between-h5py-subprocess-and-mpirun
           stdoutFile = open(prefix+"stdout.txt",'w')
           subprocess.call([ "mpirun","-np",str(numprocs),"python",
                 os.path.join(SIRISAACDIR, "generateEnsembleParallel.py"),inputDictFilename ],
-                stderr=stdoutFile,stdout=stdoutFile)
+                stderr=stdoutFile,stdout=stdoutFile,env=os.environ)
           stdoutFile.close()
           os.remove(inputDictFilename)
 
@@ -2646,12 +2639,12 @@ class EnsembleGenerator():
               os.remove(outputFilename)
               os.remove(prefix+"stdout.txt")
           except IOError:
-              print "generateEnsemble_pypar error:"
+              print "generateEnsemble_parallel error:"
               stdoutFile = open(prefix+"stdout.txt")
               stdout = stdoutFile.read()
               print stdout
               os.remove(prefix+"stdout.txt")
-              raise Exception, "generateEnsemble_pypar:"                        \
+              raise Exception, "generateEnsemble_parallel:"                        \
                   + " error in generateEnsembleParallel.py"
 
           return output

--- a/SirIsaac/generateEnsembleParallel.py
+++ b/SirIsaac/generateEnsembleParallel.py
@@ -8,27 +8,15 @@
 
 #!/usr/bin/env python
 from numpy import *
-import pypar
 import time
 
 #from generateFightData import *
 from fittingProblem import *
 import sys
 
-# for parallel computation supported by SloppyCell
+# use parallel computation supported by SloppyCell
+# (in cost and sensitivity calculations)
 import SloppyCell.ReactionNetworks.RunInParallel as Par
-
-
-# Constants
-MASTER_PROCESS = 0
-WORK_TAG = 1
-DIE_TAG = 2
-
-MPI_myID = pypar.rank() #Par.my_rank 
-num_processors = pypar.size() #Par.num_procs
-
-if num_processors < 2:
-    raise Exception, "Pypar has failed to initialize more than one processor."
 
 # read in arguments from command line file name
 if len(sys.argv) < 2 or len(sys.argv) > 2:
@@ -43,13 +31,10 @@ returnCosts = inputDict['returnCosts']
 scaleByDOF = inputDict['scaleByDOF']
 outputFilename = inputDict['outputFilename']
 inputDict['outputDict'] = {}
-fitFunction = lambda startParamsIndex:                          \
-    fittingProblem.localFitToData(fittingData,dataModel,        \
-    retall=True,startParams=startParamsList[startParamsIndex])
 
 allOutputsDict = {}
 
-output = ensGen.generateEnsemble(dataModel,initialParameters,   \
+output = ensGen.generateEnsemble(dataModel,initialParameters,
     returnCosts=returnCosts,scaleByDOF=scaleByDOF)
 
 # Write data to file

--- a/SirIsaac/generateEnsembleParallel.py
+++ b/SirIsaac/generateEnsembleParallel.py
@@ -19,8 +19,8 @@ import sys
 import SloppyCell.ReactionNetworks.RunInParallel as Par
 
 # read in arguments from command line file name
-if len(sys.argv) < 2 or len(sys.argv) > 2:
-    print "Usage: python generateEnsembleParallel.py inputDictFile.data"
+if len(sys.argv) < 2:
+    print "Usage: python generateEnsembleParallel.py inputDictFile.data [SloppyCell options]"
     exit()
 inputDictFile = sys.argv[1]
 inputDict = load(inputDictFile)

--- a/SirIsaac/localFitParallel.py
+++ b/SirIsaac/localFitParallel.py
@@ -145,5 +145,4 @@ else:
 #### while
 #### if worker
 
-comm.finalize()
 

--- a/SirIsaac/mpi_basic.py
+++ b/SirIsaac/mpi_basic.py
@@ -1,0 +1,69 @@
+# mpi_basic.py
+#
+# Bryan Daniels
+# 2020/04/20
+#
+# Basic MPI functionality.  As of 2020/06/03, only used by test_parallel.
+#
+# Run like so:
+#   mpirun -np 3 python mpi_test.py test_input_filename
+#
+
+import sys
+from simplePickle import load,save
+
+from mpi4py import MPI
+comm = MPI.COMM_WORLD
+my_rank = comm.Get_rank()
+num_procs = comm.Get_size()
+
+if __name__ == '__main__':
+    
+    if len(sys.argv) < 2 or len(sys.argv) > 2:
+        print "Usage: mpirun -np [numprocs] python mpi_test.py test_input_filename"
+        exit()
+    test_input_filename = sys.argv[1]
+    
+    if num_procs < 2:
+        raise Exception("No worker processes detected.")
+
+    if my_rank == 0:
+    
+        # master process
+        
+        file_data = load(test_input_filename)
+    
+        # send work
+        for worker in range(1,num_procs):
+            comm.send(("file_data['test']",
+                       {'comp':{1:2},'file_data':file_data}),
+                      dest=worker)
+            
+        # get results
+        for worker in range(1,num_procs):
+            msg = comm.recv(source=worker)
+            print("mpi_test: Worker {} said {}".format(worker,msg))
+            file_data['test_output'] = msg
+            
+        # stop workers
+        for worker in range(1, num_procs):
+            comm.send(SystemExit(), dest=worker)
+            
+        save(file_data,file_data['output_filename'])
+            
+    while my_rank != 0:
+        # worker process
+        
+        # Wait for a message
+        message = comm.recv(source=0)
+        
+        if isinstance(message, SystemExit):
+            sys.exit()
+        
+        command, msg_locals = message
+        locals().update(msg_locals)
+        
+        result = eval(command)
+        comm.send(result, dest=0)
+        
+

--- a/SirIsaac/simplePickle.py
+++ b/SirIsaac/simplePickle.py
@@ -8,8 +8,8 @@ import io, sys
 import cPickle
 
 # include some old name variants for back-compatability
-import fittingProblem
-sys.modules['FittingProblem'] = fittingProblem
+#import fittingProblem
+#sys.modules['FittingProblem'] = fittingProblem
 
 def save(obj,filename):
     fout = io.open(filename,'wb')

--- a/test/test_canary.py
+++ b/test/test_canary.py
@@ -11,5 +11,8 @@ import SirIsaac
 
 class TestCanary(unittest.TestCase):
     def test_addition(self):
+        """
+        Test 1 + 1 = 2
+        """
         self.assertEqual(2, 1+1)
         

--- a/test/test_parallel.py
+++ b/test/test_parallel.py
@@ -1,0 +1,54 @@
+# 3.26.2020
+#
+# Bryan Daniels
+#
+# Tests for functions that use parallel processing through MPI.
+#
+
+import unittest
+
+import SirIsaac
+
+NUMPROCS = 2
+
+class TestParallel(unittest.TestCase):
+    def test_local_fit_parallel(self):
+        
+        # create simple SloppyCell fitting model
+        complexity = 1
+        indepParamNames = ['a']
+        outputNames = ['b']
+        m = SirIsaac.fittingProblem.CTSNFittingModel(complexity,
+            indepParamNames,outputNames)
+        
+        # create some fake data (with small added noise and constant seed)
+        numPoints = 3
+        timeInterval = [0,10]
+        noiseFracSize = 0.1
+        data = [SirIsaac.fakeData.noisyFakeData(m.net,
+                                                numPoints,
+                                                timeInterval,
+                                                noiseFracSize=noiseFracSize,
+                                                seed=0)]
+        
+        # set up fit
+        indepParamsList = [[1.]]
+        dataModel = m._SloppyCellDataModel(data,indepParamsList)
+        p = m.getParameters()
+        
+        # first run serially
+        fitParamsSerial,_ = m.localFitToData(data,dataModel,startParams=p)
+        # then run in parallel
+        ens = [p,p,p] # start from multiple (equivalent) points
+        outputDictParallel = \
+            m.localFitToData_pypar(NUMPROCS,data,dataModel,ens,indepParamsList)
+        
+        # check that we get the same answer from each parallel instance
+        testVar = fitParamsSerial.keys()[0] # just check the first parameter
+        varSerial = fitParamsSerial.getByKey(testVar)
+        varParallelList = [ result[0].getByKey(testVar) \
+                            for result in outputDictParallel.values() ]
+        for varParallel in varParallelList:
+            self.assertAlmostEqual(varSerial,varParallel)
+        
+        

--- a/test/test_parallel.py
+++ b/test/test_parallel.py
@@ -12,29 +12,59 @@ import SirIsaac.fakeData
 
 NUMPROCS = 2
 
+def test_data_and_model():
+    
+    # create simple SloppyCell fitting model with single independent parameter
+    complexity = 1
+    indepParamNames = ['a']
+    outputNames = ['b']
+    m = SirIsaac.fittingProblem.CTSNFittingModel(complexity,
+        indepParamNames,outputNames)
+    
+    # create a single set of fake data (with small added noise and constant seed)
+    numPoints = 3
+    timeInterval = [0,10]
+    noiseFracSize = 0.1 # 0.01 hangs for local_fit_parallel??
+    data = [SirIsaac.fakeData.noisyFakeData(m.net,
+                                            numPoints,
+                                            timeInterval,
+                                            noiseFracSize=noiseFracSize,
+                                            seed=0)]
+                                       
+    indepParamsList = [[1.] for d in data]
+    dataModel = m._SloppyCellDataModel(data,indepParamsList)
+                                       
+    return m,data,indepParamsList,dataModel
+
 class TestParallel(unittest.TestCase):
+
+    def test_generate_ensemble_parallel(self):
+        
+        m,data,indepParamsList,dataModel = test_data_and_model()
+        
+        # set up ensemble generation
+        p = m.getParameters()
+        totalSteps = 25
+        keepSteps = 5
+        seeds = (1,1)
+        ensGen = SirIsaac.fittingProblem.EnsembleGenerator(totalSteps,keepSteps,
+                                                           seeds=seeds)
+        
+        # first run serially
+        ensSerial,_ = ensGen.generateEnsemble(dataModel,p)
+        # then run in parallel
+        ensParallel,_ = ensGen.generateEnsemble_pypar(NUMPROCS,dataModel,p)
+        
+        # check that we get the same answer when running in parallel
+        for paramIndex in range(len(ensSerial[0])):
+            self.assertAlmostEqual(ensSerial[0][paramIndex],
+                                   ensParallel[0][paramIndex])
+
     def test_local_fit_parallel(self):
         
-        # create simple SloppyCell fitting model
-        complexity = 1
-        indepParamNames = ['a']
-        outputNames = ['b']
-        m = SirIsaac.fittingProblem.CTSNFittingModel(complexity,
-            indepParamNames,outputNames)
-        
-        # create some fake data (with small added noise and constant seed)
-        numPoints = 3
-        timeInterval = [0,10]
-        noiseFracSize = 0.1 # 0.01 hangs??
-        data = [SirIsaac.fakeData.noisyFakeData(m.net,
-                                                numPoints,
-                                                timeInterval,
-                                                noiseFracSize=noiseFracSize,
-                                                seed=0)]
+        m,data,indepParamsList,dataModel = test_data_and_model()
         
         # set up fit
-        indepParamsList = [[1.]]
-        dataModel = m._SloppyCellDataModel(data,indepParamsList)
         p = m.getParameters()
         
         # first run serially

--- a/test/test_parallel.py
+++ b/test/test_parallel.py
@@ -9,15 +9,19 @@ import unittest
 
 import SirIsaac.fittingProblem
 import SirIsaac.fakeData
+from SirIsaac.simplePickle import load,save
+import subprocess
+import os
 
 NUMPROCS = 2
+SIRISAACDIR = SirIsaac.fittingProblem.SIRISAACDIR
 
-def test_data_and_model():
+def example_data_and_model():
     
     # create simple SloppyCell fitting model with single independent parameter
     complexity = 1
-    indepParamNames = ['a']
-    outputNames = ['b']
+    indepParamNames = ['input']
+    outputNames = ['output']
     m = SirIsaac.fittingProblem.CTSNFittingModel(complexity,
         indepParamNames,outputNames)
     
@@ -25,44 +29,53 @@ def test_data_and_model():
     numPoints = 3
     timeInterval = [0,10]
     noiseFracSize = 0.1 # 0.01 hangs for local_fit_parallel??
+    lenData = 1 # (2 is probably a better test for parallel stuff in generateEnsemble)
     data = [SirIsaac.fakeData.noisyFakeData(m.net,
                                             numPoints,
                                             timeInterval,
                                             noiseFracSize=noiseFracSize,
-                                            seed=0)]
+                                            seed=seed) for seed in range(lenData)]
                                        
-    indepParamsList = [[1.] for d in data]
+    indepParamsList = [[1.+i] for i in range(lenData)]
     dataModel = m._SloppyCellDataModel(data,indepParamsList)
                                        
     return m,data,indepParamsList,dataModel
 
+
 class TestParallel(unittest.TestCase):
 
-    def test_generate_ensemble_parallel(self):
+    def test_basic_mpi_functionality(self):
+        """
+        Test basic MPI functionality
+        """
+        temp_input_filename = os.path.join(SIRISAACDIR,
+                                           "temporary_input_{}.dat".format(os.getpid()))
+        temp_output_filename = os.path.join(SIRISAACDIR,
+                                            "temporary_output_{}.dat".format(os.getpid()))
+        temp_stdout_filename = os.path.join(SIRISAACDIR,
+                                            "temporary_stdout_{}.txt".format(os.getpid()))
         
-        m,data,indepParamsList,dataModel = test_data_and_model()
-        
-        # set up ensemble generation
-        p = m.getParameters()
-        totalSteps = 25
-        keepSteps = 5
-        seeds = (1,1)
-        ensGen = SirIsaac.fittingProblem.EnsembleGenerator(totalSteps,keepSteps,
-                                                           seeds=seeds)
-        
-        # first run serially
-        ensSerial,_ = ensGen.generateEnsemble(dataModel,p)
-        # then run in parallel
-        ensParallel,_ = ensGen.generateEnsemble_pypar(NUMPROCS,dataModel,p)
-        
-        # check that we get the same answer when running in parallel
-        for paramIndex in range(len(ensSerial[0])):
-            self.assertAlmostEqual(ensSerial[0][paramIndex],
-                                   ensParallel[0][paramIndex])
+        input_data = {'test':123,'output_filename':temp_output_filename}
+        save(input_data,temp_input_filename)
+        stdoutFile = open(temp_stdout_filename,'w')
+        subprocess.call([ "mpirun","-np",str(NUMPROCS),"python",
+                          os.path.join(SIRISAACDIR, "mpi_basic.py"),
+                          temp_input_filename ],
+                          stderr=stdoutFile,stdout=stdoutFile,
+                          env=os.environ)
+        output_data = load(temp_output_filename)
+        os.remove(temp_input_filename)
+        os.remove(temp_output_filename)
+        os.remove(temp_stdout_filename)
+
+        self.assertTrue(input_data['test'] == output_data['test_output'])
 
     def test_local_fit_parallel(self):
+        """
+        Test localFitToData_parallel
+        """
         
-        m,data,indepParamsList,dataModel = test_data_and_model()
+        m,data,indepParamsList,dataModel = example_data_and_model()
         
         # set up fit
         p = m.getParameters()
@@ -81,5 +94,32 @@ class TestParallel(unittest.TestCase):
                             for result in outputDictParallel.values() ]
         for varParallel in varParallelList:
             self.assertAlmostEqual(varSerial,varParallel)
+
+    def test_generate_ensemble_parallel(self):
+        """
+        Test generateEnsemble_parallel
+        """
+
+        m,data,indepParamsList,dataModel = example_data_and_model()
+
+        # set up ensemble generation
+        p = m.getParameters()
+        totalSteps = 25
+        keepSteps = 5
+        seeds = (1,1)
+        ensGen = SirIsaac.fittingProblem.EnsembleGenerator(totalSteps,keepSteps,
+                                                           seeds=seeds)
+
+        # first run serially
+        ensSerial,_ = ensGen.generateEnsemble(dataModel,p)
+        # then run in parallel
+        ensParallel,_ = ensGen.generateEnsemble_parallel(NUMPROCS,dataModel,p)
+
+        # check that we get the same answer when running in parallel
+        for paramIndex in range(len(ensSerial[0])):
+            self.assertAlmostEqual(ensSerial[0][paramIndex],
+                                   ensParallel[0][paramIndex])
+
+    
         
         

--- a/test/test_parallel.py
+++ b/test/test_parallel.py
@@ -7,7 +7,8 @@
 
 import unittest
 
-import SirIsaac
+import SirIsaac.fittingProblem
+import SirIsaac.fakeData
 
 NUMPROCS = 2
 
@@ -24,7 +25,7 @@ class TestParallel(unittest.TestCase):
         # create some fake data (with small added noise and constant seed)
         numPoints = 3
         timeInterval = [0,10]
-        noiseFracSize = 0.1
+        noiseFracSize = 0.1 # 0.01 hangs??
         data = [SirIsaac.fakeData.noisyFakeData(m.net,
                                                 numPoints,
                                                 timeInterval,
@@ -41,7 +42,7 @@ class TestParallel(unittest.TestCase):
         # then run in parallel
         ens = [p,p,p] # start from multiple (equivalent) points
         outputDictParallel = \
-            m.localFitToData_pypar(NUMPROCS,data,dataModel,ens,indepParamsList)
+            m.localFitToData_parallel(NUMPROCS,data,dataModel,ens,indepParamsList)
         
         # check that we get the same answer from each parallel instance
         testVar = fitParamsSerial.keys()[0] # just check the first parameter


### PR DESCRIPTION
This should fix issues with hanging during parallel execution.  

The issue seems to be within SloppyCell, which, when using newer versions of openmpi, hangs while passing network objects whose C code must be recompiled when received by worker processes.  My attempts to fix the issue within SloppyCell failed, so for now we will just disable C compiling completely when generating ensembles in parallel.  This could be slower than the C version, but at least it will work.

This also adds more thorough testing for parallel execution.